### PR TITLE
Add community hub lifecycle badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Community Extension Badge](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)
+[![Lifecycle: Incubating Badge](https://img.shields.io/badge/Lifecycle-Incubating-blue)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-)
+
 # Camunda Grails Plugin 
 
 This plugin integrates **Camunda BPM** (all versions) with the **Grails 2** web 


### PR DESCRIPTION
Added a community extension badge indicating this is a community extension, a [Lifecycle: Incubating](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-) badge indicating that to my initial assessment, this project is currently 'Incubating,' though if you would prefer, we can mark it as Abandoned or archive it if it is no longer actively maintained/used.

Thank you so much for your contribution to Camunda! :)